### PR TITLE
Deploy cloudflare worker script

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,11 @@
+import html from './index.html';
+
+export default {
+  async fetch(request, env, ctx) {
+    return new Response(html, {
+      headers: {
+        'content-type': 'text/html;charset=UTF-8',
+      },
+    });
+  },
+};

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,10 @@
+name = "foreverlink-love"
+main = "index.js"
+compatibility_date = "2025-08-29"
+
+[build]
+command = ""
+
+[[rules]]
+type = "Text"
+globs = ["**/*.html"]


### PR DESCRIPTION
Add Cloudflare Worker script and configuration to deploy the static HTML site.

The initial deployment command failed because Cloudflare Wrangler could not detect a worker entry point or an assets directory. This PR introduces an `index.js` worker script that serves the existing `index.html` file, along with a `wrangler.toml` configuration, to enable successful deployment to Cloudflare Workers.

---
<a href="https://cursor.com/background-agent?bcId=bc-b44a7cf7-21c8-4d7f-ba87-b773676d4c2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b44a7cf7-21c8-4d7f-ba87-b773676d4c2b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

